### PR TITLE
Solution

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,39 +1,42 @@
 import React from 'react';
+import { getRandomName, Clock } from './components/Clock';
 import './App.scss';
 
-function getRandomName(): string {
-  const value = Date.now().toString().slice(-4);
+type Props = {};
 
-  return `Clock-${value}`;
-}
-
-export const App: React.FC = () => {
-  const today = new Date();
-  let clockName = 'Clock-0';
-
-  // This code starts a timer
-  const timerId = window.setInterval(() => {
-    clockName = getRandomName();
-  }, 3300);
-
-  // this code stops the timer
-  window.clearInterval(timerId);
-
-  return (
-    <div className="App">
-      <h1>React clock</h1>
-
-      <div className="Clock">
-        <strong className="Clock__name">
-          {clockName}
-        </strong>
-
-        {' time is '}
-
-        <span className="Clock__time">
-          {today.toUTCString().slice(-12, -4)}
-        </span>
-      </div>
-    </div>
-  );
+type State = {
+  clockName: string,
+  hasClock: boolean,
 };
+
+export class App extends React.Component<Props, State> {
+  state = {
+    clockName: 'Clock-0',
+    hasClock: true,
+  };
+
+  componentDidMount() {
+    document.addEventListener('contextmenu', (event) => {
+      this.handleContextMenu(event);
+    });
+    document.addEventListener('click', this.handleClick);
+  }
+
+  handleClick = () => (this.setState({ hasClock: true }));
+
+  handleContextMenu = (event: Event) => {
+    event.preventDefault();
+    this.setState({ hasClock: false, clockName: getRandomName() });
+  };
+
+  render() {
+    return (
+      <div className="App">
+        <h1>React clock</h1>
+        {this.state.hasClock && (
+          <Clock clockName={this.state.clockName} />
+        )}
+      </div>
+    );
+  }
+}

--- a/src/components/Clock/Clock.tsx
+++ b/src/components/Clock/Clock.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+export function getRandomName(): string {
+  const value = (Date.now()).toString().slice(-4);
+
+  return `Clock-${value}`;
+}
+
+type State = {
+  today: Date,
+  clockName: string,
+};
+
+type Props = {
+  clockName: string,
+};
+
+let nametimerID: number;
+let clocktimerID: number;
+
+export class Clock extends React.Component<Props, State> {
+  state = {
+    today: new Date(),
+    /* eslint-disable react/no-unused-state */
+    clockName: this.props.clockName,
+  };
+
+  componentDidMount() {
+    nametimerID = window.setInterval(
+      () => this.updateClockName(),
+      3300,
+    );
+    clocktimerID = window.setInterval(
+      () => this.updateClock(),
+      1000,
+    );
+  }
+
+  componentDidUpdate(_: Props, prevState: State) {
+    if (prevState.clockName !== this.state.clockName) {
+      /* eslint-disable no-console */
+      console.debug(`Renamed from ${prevState.clockName} to ${this.state.clockName}`);
+    }
+  }
+
+  componentWillUnmount() {
+    window.clearInterval(nametimerID);
+    window.clearInterval(clocktimerID);
+  }
+
+  updateClockName() {
+    this.setState({
+      /* eslint-disable react/no-unused-state */
+      clockName: getRandomName(),
+    });
+  }
+
+  updateClock() {
+    this.setState({
+      today: new Date(),
+    });
+    /* eslint-disable no-console */
+    console.info(this.state.today.toUTCString().slice(-12, -4));
+  }
+
+  render() {
+    return (
+      <div className="Clock">
+        <>
+          <strong className="Clock__name">
+            {this.state.clockName}
+          </strong>
+          {' time is '}
+          <span className="Clock__time">
+            {this.state.today.toUTCString().slice(-12, -4)}
+          </span>
+        </>
+      </div>
+    );
+  }
+}

--- a/src/components/Clock/index.tsx
+++ b/src/components/Clock/index.tsx
@@ -1,0 +1,1 @@
+export * from './Clock';


### PR DESCRIPTION
[DEMO LINK](https://bokorzita.github.io/react_clock/)

Hello, I added some comments to disable no log statements because I didn't know how else to circumvent the linter, also for unused state because I'm changing the state of the clock name which is accepted as a prop, let me know if there is a better way to do this. The clock name resets to the initial 'Clock-0' upon restarting the timer as of now, not sure if it should save the last name it was changed to before unmounting and start with that or call a completely new name immediately, the tests were not passing when it came to actual clock name.